### PR TITLE
PEP8, more pythonic, using wrapper errors etc...

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,48 +2,67 @@
 import discord
 import asyncio
 import sys
+
 from arcadia import Client
-# You have to replace API_KEY to your arcadia token
-arctoken = 'API_KEY'
+from arcadia.errors import Forbidden, InvalidEndPoint
+
+arctoken = 'API_KEY'  # You have to replace API_KEY to your arcadia token
 arcadia = Client(token=arctoken)
 
-# You have to replace BOT_TOKEN to your bot token
-token = 'BOT_TOKEN'
-prefix = 'b!'
-admin = 240508683455299584
+token = 'BOT_TOKEN'  # You have to replace BOT_TOKEN to your bot token
+prefix = 'b!'  # Custom prefix
+owner_id = 'OWNER_ID'  # You have to replace OWNER_ID to your ID
+
 
 class Bot(discord.Client):
+    """Bot class"""
+
     async def on_ready(self):
-        await self.change_presence(activity=discord.Game(name=prefix+"help"))
-        print(self.user.name+' connecté !')
+        game = discord.Game(name='{}help'.format(prefix))
+        await self.change_presence(activity=game)
+        print('Connected as: {} ({})'.format(str(self.user), str(self.user.id)))
+        print('Owner: {}'.format(owner_id))
 
     async def on_message(self, message):
-
         if message.author == self.user:
             return
 
-        if message.content.startswith(prefix+'logout'):
-            if message.author.id != admin:
-                return await message.channel.send('⚠ You\'re not my owner.')
+        if not message.content.startswith(prefix):
+            return
+
+        command = message.content.lower().strip()[len(prefix):]  # Case insensitive
+
+        if command.startswith('logout'):
+            if message.author.id != int(owner_id):
+                await message.channel.send('⚠ You\'re not my owner.')
             else:
                 await message.channel.send('💤 I will go to sleep...')
-                await sys.exit();
+                await sys.exit()
 
-        if message.content.startswith(prefix+'arcadia'):
-            if message.content.split(" ")[1]:
-                try:
-                    image = await arcadia.get_image(message.content.split(" ")[1], message.author.avatar_url_as(format='png'))
-                    await message.channel.send(file=image)
-                except:
-                        await message.channel.send('❌ An error has occured.')
-            else:
-                    await message.channel.send('⚠ You must provide an endpoint.')
+        elif command.startswith('arcadia'):
+            if len(message.content.split(' ')) < 2:
+                return await message.channel.send('⚠ You must provide an endpoint.')
 
-        elif message.content.startswith(prefix+'help'):
-                Embed = discord.Embed(description='Here\'s my commands:', colour=0x36393f)
-                Embed.set_author(name='Bowsette', icon_url=self.user.avatar_url)
-                Embed.add_field(name='b!arcadia <endpoint>', value='Some endpoints: `angry`, `animeprotest`, `beautiful`, `blood`, `bloodhelp`, `bluely`, `blur`, `blurblack`, `blureen`, `blurey`, `blurple`, `bob`, `brazzers`, `codebabes`, `convinvert`, `convmatrix`, `convolute`, `cyanly`, `discordlogo`, `displace`, `distortion`, `gay`, `ghost`, `glitch`, `goodbye`, `grayscale`, `hitler`, `hypesquad`, `illuminati`, `implode`, `invert`, `jackolantern`, `link`, `loveship`, `magik`, `orangblur`, `orangly`, `pixelate`, `posterize`, `purply`, `rainbow`, `respect`, `sepia`, `shocked`, `snow`, `thisexample`, `thisfilm`, `time`, `tobecontinued`, `triggered`, `triggeredinvert`, `waifu`, `wanted`, `wasted`, `welcome`, `whoisthis`, `yelloblur`, `youporn`', inline=True)
-                await message.channel.send(embed=Embed)
+            endpoint = message.content.split(' ')[1]  # Only works if endpoints are in one word
+
+            try:
+                image = await arcadia.get_image(endpoint, message.author.avatar_url_as(format='png'))
+                await message.channel.send(file=image)
+            except Forbidden:
+                await message.channel.send('❌ You are not allowed to access this endpoint.')
+            except InvalidEndPoint:
+                await message.channel.send('❌ This endpoint doesn\'t exist!')
+
+        elif command.startswith('help'):
+            embed = discord.Embed(description='Here\'s my commands:', colour=0x36393f)
+            embed.set_author(name=self.user.name, icon_url=self.user.avatar_url)
+            endpoints = '`{}`'.format('`, `'.join(arcadia.endpoints))
+            embed.add_field(name='{}arcadia <endpoint>'.format(prefix), value=endpoints)
+            embed.add_field(name='{}help'.format(prefix), value='Displays this message', inline=False)
+            if message.author.id == int(owner_id):
+                embed.add_field(name='{}logout'.format(prefix), value='To ask me to disconnect myself', inline=False)
+            await message.channel.send(embed=embed)
+
 
 client = Bot()
 client.run(token)


### PR DESCRIPTION
- PEP8 friendly
- More pythonic
- Readable code (right indentation)
- Using wrapper tools such as `arcadia.errors` or `Client.endpoints` to fetch the list of available endpoints
- Using variables instead of fixed string in help command
- Removing useless `return`
- Adding commands in help message
- `.format()` instead of concatenation
- Allows `OWNER_ID` to be either integer or string